### PR TITLE
Upgrading openjdk dependency to version 8.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ CMD ["bash"]
 RUN apk update && \
   apk add \
     nss \
-    openjdk7 && \
+    openjdk8 && \
   rm -rf /var/cache/apk/*
 
 ADD rootfs /


### PR DESCRIPTION
Hello,

For my personal needs I wanted to have a Java 8 container, and seems to me it makes sense to update your image also. Could be even better if this image had different branches for other/older versions.